### PR TITLE
lighthouse 접근성 개선

### DIFF
--- a/apps/frontend/src/features/auth/ui/LoginForm/index.tsx
+++ b/apps/frontend/src/features/auth/ui/LoginForm/index.tsx
@@ -10,14 +10,14 @@ export function LoginForm() {
           className="flex h-12 w-64 items-center justify-center gap-2 rounded-lg bg-[#FEE500] bg-cover bg-no-repeat text-[rgba(0,0,0,0.85)]"
           href="/api/auth/kakao"
         >
-          <img className="w-4" src={KakaoLogo}></img>
+          <img className="w-4" src={KakaoLogo} alt="KakaoLogo"></img>
           카카오 로그인
         </a>
         <a
           className="flex h-12 w-64 items-center justify-center gap-2 rounded-lg bg-[#03C75A] bg-cover bg-no-repeat text-[#ffffff]"
           href="/api/auth/naver"
         >
-          <img className="w-4" src={NaverLogo}></img>
+          <img className="w-4" src={NaverLogo} alt="NaverLogo"></img>
           네이버 로그인
         </a>
       </div>

--- a/apps/frontend/src/features/canvas/ui/Canvas/index.tsx
+++ b/apps/frontend/src/features/canvas/ui/Canvas/index.tsx
@@ -80,7 +80,7 @@ export function Canvas({ className }: CanvasProps) {
         <div
           className={cn(
             status === "connected" && "text-green-500",
-            status === "connecting" && "text-amber-500",
+            status === "connecting" && "text-yellow-700",
             status === "disconnected" && "text-red-500",
             "fixed bottom-5 left-16 z-30 text-xs hover:cursor-pointer",
           )}
@@ -89,7 +89,7 @@ export function Canvas({ className }: CanvasProps) {
             <div
               className={cn(
                 status === "connected" && "bg-green-500",
-                status === "connecting" && "bg-amber-500",
+                status === "connecting" && "bg-yellow-700",
                 status === "disconnected" && "bg-red-500",
                 "h-2 w-2 rounded-full",
               )}

--- a/apps/frontend/src/features/canvasTools/ui/CursorButton/index.tsx
+++ b/apps/frontend/src/features/canvasTools/ui/CursorButton/index.tsx
@@ -6,7 +6,10 @@ interface CursorButtonProps {
 
 export function CursorButton({ color }: CursorButtonProps) {
   return (
-    <button className="flex h-9 w-9 items-center justify-center rounded-md hover:bg-[#F5F5F5]">
+    <button
+      className="flex h-9 w-9 items-center justify-center rounded-md hover:bg-[#F5F5F5]"
+      aria-label="CursorBtn"
+    >
       <MousePointer fill={color} className="h-6 w-6" />
     </button>
   );

--- a/apps/frontend/src/features/pageSidebar/ui/LogoBtn/index.tsx
+++ b/apps/frontend/src/features/pageSidebar/ui/LogoBtn/index.tsx
@@ -9,6 +9,7 @@ export function LogoBtn({ onClick }: LogoBtnProps) {
     <button
       className="h-8 w-8 overflow-clip rounded-md bg-[#231f20] p-1"
       onClick={onClick}
+      aria-label="LogoBtn"
     >
       <img src={logo} />
     </button>

--- a/apps/frontend/src/features/pageSidebar/ui/LogoBtn/index.tsx
+++ b/apps/frontend/src/features/pageSidebar/ui/LogoBtn/index.tsx
@@ -11,7 +11,7 @@ export function LogoBtn({ onClick }: LogoBtnProps) {
       onClick={onClick}
       aria-label="LogoBtn"
     >
-      <img src={logo} />
+      <img src={logo} alt="logo" />
     </button>
   );
 }

--- a/apps/frontend/src/features/workspace/model/workspaceQuries.ts
+++ b/apps/frontend/src/features/workspace/model/workspaceQuries.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 
 import { getUserWorkspaces, getCurrentWorkspace } from "../api/workspaceApi";
 import { useGetUser } from "@/features/auth";
@@ -17,10 +17,9 @@ export const useCurrentWorkspace = () => {
 
   const snowflakeId = isError ? "null" : (user?.snowflakeId ?? "null");
 
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ["currentWorkspace", workspaceId, snowflakeId],
     queryFn: () => getCurrentWorkspace(workspaceId, snowflakeId),
-    enabled: Boolean(workspaceId),
     retry: false,
     refetchOnWindowFocus: false,
   });

--- a/apps/frontend/src/features/workspace/ui/ShareTool/ShareButton.tsx
+++ b/apps/frontend/src/features/workspace/ui/ShareTool/ShareButton.tsx
@@ -3,7 +3,7 @@ export function Sharebutton() {
     <div className="flex h-9 items-center justify-center">
       <button
         type="button"
-        className="rounded-md bg-blue-400 px-2 py-1 text-sm text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded-md bg-blue-600 px-2 py-1 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
       >
         공유
       </button>

--- a/apps/frontend/src/widgets/TopNavView/ui/index.tsx
+++ b/apps/frontend/src/widgets/TopNavView/ui/index.tsx
@@ -31,7 +31,7 @@ export function TopNavView({ onExpand, isExpanded }: TopNavProps) {
         </Suspense>
       </div>
       <div className="flex h-7 w-7 items-center justify-center">
-        <button onClick={onExpand}>
+        <button onClick={onExpand} aria-label="MenuBtn">
           {isExpanded ? (
             <X color="#3F3F3F" />
           ) : (

--- a/apps/frontend/src/widgets/TopNavView/ui/index.tsx
+++ b/apps/frontend/src/widgets/TopNavView/ui/index.tsx
@@ -3,17 +3,18 @@ import { Menu, X } from "lucide-react";
 import { WorkspaceNav } from "@/features/pageSidebar";
 import { useCurrentWorkspace } from "@/features/workspace";
 import { UserInfoView } from "@/widgets/UserInfoView";
-import { Divider } from "@/shared/ui";
+import { Divider, Skeleton } from "@/shared/ui";
+import { Suspense } from "react";
 
 interface TopNavProps {
   onExpand: () => void;
   isExpanded: boolean;
 }
 export function TopNavView({ onExpand, isExpanded }: TopNavProps) {
-  const { data } = useCurrentWorkspace();
+  const { data, isLoading } = useCurrentWorkspace();
 
   const getWorkspaceTitle = () => {
-    if (!data) return "로딩 중";
+    if (!data || isLoading) return "로딩 중";
 
     if (data.workspace.workspaceId === "main") return "공용 워크스페이스";
 
@@ -25,7 +26,9 @@ export function TopNavView({ onExpand, isExpanded }: TopNavProps) {
       <div className="flex flex-row items-center gap-2">
         <UserInfoView />
         <Divider direction="vertical" className="h-3" />
-        <WorkspaceNav title={getWorkspaceTitle()} />
+        <Suspense fallback={<Skeleton className="h-[24px] w-[110px]" />}>
+          <WorkspaceNav title={getWorkspaceTitle()} />
+        </Suspense>
       </div>
       <div className="flex h-7 w-7 items-center justify-center">
         <button onClick={onExpand}>


### PR DESCRIPTION
## 🔖 연관된 이슈

- closes #18 

## 📂 작업 내용

- button에 aria-label 지정
- 이미지 태그에 alt 속성 지정
- 백그라운드와 포그라운드 대비 수정
  - 공유버튼 (`bg-blue-400` -> `bg-blue-600`)
  - connecting 상태 (`text-amber-500` -> `text-yellow-700`)

- 기존 83점에서 100점으로 개선
![image](https://github.com/user-attachments/assets/64061b05-a363-40be-a485-3682066a7192)
