### PR TITLE
docker .env bind mount 제거

### DIFF
--- a/.github/workflows/auto-assign-merge.yml
+++ b/.github/workflows/auto-assign-merge.yml
@@ -68,9 +68,9 @@ jobs:
                           ? context.payload.pull_request.requested_reviewers.map(r => r.login)
                           : [];
 
-                      const BE_reviewers = ['summersummerwhy', 'ezcolin2', 'Tolerblanc'];
-                      const FE_reviewers = ['yewonJin', 'djk01281'];
-                      const doc_reviewers = ['summersummerwhy', 'ezcolin2', 'Tolerblanc', 'yewonJin', 'djk01281'];
+                      const BE_reviewers = ['summersummerwhy', 'ezcolin2'];
+                      const FE_reviewers = ['baegyeong', 'pkh0106'];
+                      const doc_reviewers = ['summersummerwhy', 'ezcolin2', 'baegyeong', 'pkh0106'];
 
                       // Function to filter out assignees, PR author, and current reviewers
                       const filterReviewers = (reviewers) => {

--- a/apps/backend/src/auth/auth.controller.spec.ts
+++ b/apps/backend/src/auth/auth.controller.spec.ts
@@ -29,6 +29,10 @@ describe('AuthController', () => {
             refreshAccessToken: jest.fn(() => 'mockedAccessToken'),
           },
         },
+        {
+          provide: JwtAuthGuard,
+          useValue: {},
+        },
       ],
     })
       .overrideGuard(JwtAuthGuard)

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -3,16 +3,14 @@ version: "3.8"
 services:
   postgres:
     image: postgres:16-alpine
-    environment:
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_DB: ${DB_NAME}
+    env_file:
+      - .env.local
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - net
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -21,9 +19,8 @@ services:
 
   redis:
     image: redis:latest
-    environment:
-      REDIS_HOST: ${REDIS_HOST}
-      REDIS_PORT: ${REDIS_PORT}
+    env_file:
+      - .env.local
     networks:
       - net
     ports:
@@ -40,9 +37,8 @@ services:
       dockerfile: ./services/frontend/Dockerfile.local
     image: frontend:latest
     env_file:
-      - .env
+      - .env.local
     volumes:
-      - .env:/app/.env
       - ./apps/frontend:/app/apps/frontend
 
     networks:
@@ -56,9 +52,8 @@ services:
       dockerfile: ./services/backend/Dockerfile.local
     image: backend:latest
     env_file:
-      - .env
+      - .env.local
     volumes:
-      - .env:/app/.env
       - ./apps/backend:/app/apps/backend
     depends_on:
       postgres:
@@ -76,9 +71,8 @@ services:
       dockerfile: ./services/websocket/Dockerfile.local
     image: websocket:latest
     env_file:
-      - .env
+      - .env.local
     volumes:
-      - .env:/app/.env
       - ./apps/websocket:/app/apps/websocket
     depends_on:
       postgres:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -3,6 +3,8 @@ version: "3.8"
 services:
   nginx:
     image: summersummerwhy/octodocs-nginx:latest
+    env_file:
+      - .env.server
     restart: always
     ports:
       - "80:80"
@@ -20,8 +22,8 @@ services:
 
   backend:
     image: summersummerwhy/octodocs-backend:latest
-    volumes:
-      - ./.env.server:/app/apps/backend/.env
+    env_file:
+      - .env.server
     expose:
       - "3000"
     networks:
@@ -48,8 +50,8 @@ services:
 
   websocket:
     image: summersummerwhy/octodocs-websocket:latest
-    volumes:
-      - ./.env.server:/app/apps/websocket/.env
+    env_file:
+      - .env.server
     expose:
       - "4242"
     networks:
@@ -78,9 +80,8 @@ services:
 
   redis:
     image: redis:latest
-    environment:
-      REDIS_HOST: ${REDIS_HOST}
-      REDIS_PORT: ${REDIS_PORT}
+    env_file:
+      - .env.server
     networks:
       - backend
       - frontend


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #45 

## 📂 작업 내용

- docker-compose 파일 environment 제거
- docker-compose 파일 .env bind mount 제거
- env_file로 .env 파일 위치 알려주는 방식으로 변경
- JwtAuthGuard 주입되지 않아서 AuthController test 실패하던 이슈 해결
- reviewer에서 현준님 제거

저번 피어세션 시간에 보안을 위해 .env 파일을 bind mount했다고 발표를 하니 한 분께서 docker-compose에서 제공해주는 env_file을 사용하면 bind mount 없이도 쉽게 환경 변수를 주입할 수 있다고 하셔서 적용해보았습니다.

bind mount 자체를 없앨 수 있어서 좋은 것 같습니다.

그리고 AuthController test에 JwtAuthGuard 주입 추가했고 현준님 자동 리뷰어로 등록되는 현상 있어서 현준님 리뷰어 그룹에서 제거했습니다.

## 📑 참고 자료
https://docs.docker.com/compose/how-tos/environment-variables/set-environment-variables/
