### PR TITLE
docker 자동 배포 pipeline 시간 단축

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -3,7 +3,7 @@ name: auto  Workflow
 on:
   push:
     branches:
-      - main
+      - refactor-be-#47
   workflow_dispatch:
 jobs:
   image-build-and-push:

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -80,4 +80,4 @@ jobs:
           ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'
             cd /root/octodocs
             docker-compose -f compose.prod.yml down
-            docker-compose -f compose.prod.yml up
+            docker-compose -f compose.prod.yml up -d

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -36,17 +36,19 @@ jobs:
       # Docker 이미지 빌드
       - name: docker image build
         run: |
-          docker build -f ./services/backend/Dockerfile.prod -t summersummerwhy/octodocs-backend .
-          docker build -f ./services/nginx/Dockerfile.prod -t summersummerwhy/octodocs-nginx .
-          docker build -f ./services/websocket/Dockerfile.prod -t summersummerwhy/octodocs-websocket .
+          docker build -f ./services/backend/Dockerfile.prod -t summersummerwhy/octodocs-backend . &
+          docker build -f ./services/nginx/Dockerfile.prod -t summersummerwhy/octodocs-nginx . &
+          docker build -f ./services/websocket/Dockerfile.prod -t summersummerwhy/octodocs-websocket . &
+          wait
 
       # Docker 이미지 푸시
       - name: docker image push
         run: |
-          docker push summersummerwhy/octodocs-modules
-          docker push summersummerwhy/octodocs-backend
-          docker push summersummerwhy/octodocs-nginx
-          docker push summersummerwhy/octodocs-websocket
+          docker push summersummerwhy/octodocs-modules &
+          docker push summersummerwhy/octodocs-backend &
+          docker push summersummerwhy/octodocs-nginx &
+          docker push summersummerwhy/octodocs-websocket &
+          wait
 
   deploy:
     needs: image-build-and-push

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -91,3 +91,11 @@ jobs:
             cd /root/octodocs
             docker-compose -f compose.prod.yml down
             docker-compose -f compose.prod.yml up -d
+      # 사용하지 않는 도커 리소스를 정리한다.
+      - name: cleanup
+        env:
+          REMOTE_HOST: ${{ secrets.REMOTE_SERVER_IP }}
+          REMOTE_USER: ${{ secrets.REMOTE_SERVER_USER }}
+          SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        run: docker system prune -f --all

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -31,15 +31,22 @@ jobs:
       # 이 이미지를 base로 backend와 websocket 이미지를 만들기 때문
       # 만약 octodocs-modules 이미지가 존재하면 그 이미지를 base로 하고
       # 그렇지 않으면 node:20-alpine 버전 사용
+      # 그리고 layer 수가 너무 많으면 node:20-alpine 버전 사용 (50개 이상)
       - name: package docker image build and push
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://hub.docker.com/v2/repositories/summersummerwhy/octodocs-modules)
           if [ "$STATUS" -eq 404 ]; then
             echo "octodocs-modules not found"
             docker build -f ./services/module/Dockerfile.init -t summersummerwhy/octodocs-modules .
+
           else
             echo "octodocs-modules found"
             docker build -f ./services/module/Dockerfile -t summersummerwhy/octodocs-modules .
+            LAYERS=$(docker inspect --format '{{len .RootFS.Layers}}' summersummerwhy/octodocs-modules)
+              if [ $LAYERS -gt 50 ]; then
+                echo "too many layers"
+                docker build -f ./services/module/Dockerfile.init -t summersummerwhy/octodocs-modules .
+              fi
           fi
       # Docker 이미지 빌드
       - name: docker image build

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -29,10 +29,18 @@ jobs:
 
       # 패키지 이미지부터 빌드 후 푸시
       # 이 이미지를 base로 backend와 websocket 이미지를 만들기 때문
+      # 만약 octodocs-modules 이미지가 존재하면 그 이미지를 base로 하고
+      # 그렇지 않으면 node:20-alpine 버전 사용
       - name: package docker image build and push
         run: |
-          docker build -f ./services/module/Dockerfile -t summersummerwhy/octodocs-modules .
-
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://hub.docker.com/v2/repositories/summersummerwhy/octodocs-modules)
+          if [ "$STATUS" -eq 404 ]; then
+            echo "octodocs-modules not found"
+            docker build -f ./services/module/Dockerfile.init -t summersummerwhy/octodocs-modules .
+          else
+            echo "octodocs-modules found"
+            docker build -f ./services/module/Dockerfile -t summersummerwhy/octodocs-modules .
+          fi
       # Docker 이미지 빌드
       - name: docker image build
         run: |

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -91,8 +91,6 @@ jobs:
         env:
           REMOTE_HOST: ${{ secrets.REMOTE_SERVER_IP }}
           REMOTE_USER: ${{ secrets.REMOTE_SERVER_USER }}
-          SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         run: |
           ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'
             cd /root/octodocs
@@ -103,6 +101,6 @@ jobs:
         env:
           REMOTE_HOST: ${{ secrets.REMOTE_SERVER_IP }}
           REMOTE_USER: ${{ secrets.REMOTE_SERVER_USER }}
-          SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        run: docker system prune -f --all
+        run: |
+          ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'
+            docker system prune -f --all

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -1,4 +1,4 @@
-name: auto  Workflow
+name: OctoDocs CD Pipeline
 
 on:
   push:
@@ -53,7 +53,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: deploy
+      # octodocs-modules먼저 pull 한 뒤 나머지 이미지 pull
+      # octodocs-modules를 base로 하는 이미지가 있기 때문
+      - name: image-pulling
         env:
           REMOTE_HOST: ${{ secrets.REMOTE_SERVER_IP }}
           REMOTE_USER: ${{ secrets.REMOTE_SERVER_USER }}
@@ -66,6 +68,16 @@ jobs:
 
           ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'
             cd /root/octodocs
-            docker-compose -f compose.prod.yml down
+            docker pull summersummerwhy/octodocs-modules
             docker-compose -f compose.prod.yml pull
-            docker-compose -f compose.prod.yml up -d
+      - name: deploy
+        env:
+          REMOTE_HOST: ${{ secrets.REMOTE_SERVER_IP }}
+          REMOTE_USER: ${{ secrets.REMOTE_SERVER_USER }}
+          SSH_KEY: ${{ secrets.REMOTE_PRIVATE_KEY }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        run: |
+          ssh -o StrictHostKeyChecking=no $REMOTE_USER@$REMOTE_HOST << 'EOF'
+            cd /root/octodocs
+            docker-compose -f compose.prod.yml down
+            docker-compose -f compose.prod.yml up

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -27,10 +27,15 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # 패키지 이미지부터 빌드 후 푸시
+      # 이 이미지를 base로 backend와 websocket 이미지를 만들기 때문
+      - name: package docker image build and push
+        run: |
+          docker build -f ./services/module/Dockerfile -t summersummerwhy/octodocs-modules .
+
       # Docker 이미지 빌드
       - name: docker image build
         run: |
-          docker build -f ./services/module/Dockerfile -t summersummerwhy/octodocs-modules .
           docker build -f ./services/backend/Dockerfile.prod -t summersummerwhy/octodocs-backend .
           docker build -f ./services/nginx/Dockerfile.prod -t summersummerwhy/octodocs-nginx .
           docker build -f ./services/websocket/Dockerfile.prod -t summersummerwhy/octodocs-websocket .

--- a/services/module/Dockerfile
+++ b/services/module/Dockerfile
@@ -1,7 +1,7 @@
-# node_modules를 가지고 있는 이미지
-# 이 이미지를 기반으로 각 workspace 별 이미지를 만들면 
-# yarn install 레이어를 공유하게 된다.
-FROM summersummerwhy/octodocs-modules:latest
+# COPY 명령어는 여러 디렉토리를 목적지로 파일 복사하는 것이 불가능하다.
+# 빌드 스테이지에서 COPY 명령어를 여러 번 생성해서 여러 디렉토리로 파일을 복사한다.
+# 그 후 그 디렉토리 자체를 다음 스테이지에서 그대로 복사하여 layer의 개수를 줄인다.
+FROM node:20-alpine as builder 
 
 WORKDIR /app
 
@@ -10,6 +10,14 @@ COPY package.json yarn.lock ./
 COPY apps/backend/package.json ./apps/backend/
 COPY apps/frontend/package.json ./apps/frontend/
 COPY apps/websocket/package.json ./apps/websocket/
+
+# node_modules를 가지고 있는 이미지
+# 이 이미지를 기반으로 각 workspace 별 이미지를 만들면 
+# yarn install 레이어를 공유하게 된다.
+FROM summersummerwhy/octodocs-modules:latest
+
+# 호이스팅을 위해
+COPY --from=builder /app/apps /app/apps
 
 # 의존성 설치
 RUN yarn install --check-files

--- a/services/module/Dockerfile
+++ b/services/module/Dockerfile
@@ -1,7 +1,7 @@
 # node_modules를 가지고 있는 이미지
 # 이 이미지를 기반으로 각 workspace 별 이미지를 만들면 
 # yarn install 레이어를 공유하게 된다.
-FROM node:20-alpine
+FROM summersummerwhy/octodocs-modules:latest
 
 WORKDIR /app
 
@@ -12,4 +12,4 @@ COPY apps/frontend/package.json ./apps/frontend/
 COPY apps/websocket/package.json ./apps/websocket/
 
 # 의존성 설치
-RUN yarn install
+RUN yarn install --check-files

--- a/services/module/Dockerfile.init
+++ b/services/module/Dockerfile.init
@@ -1,5 +1,7 @@
-# 만약 octodocs-modules가 원격 저장소에 없으면 node 이미지를 사용한다.
-FROM node:20-alpine
+# COPY 명령어는 여러 디렉토리를 목적지로 파일 복사하는 것이 불가능하다.
+# 빌드 스테이지에서 COPY 명령어를 여러 번 생성해서 여러 디렉토리로 파일을 복사한다.
+# 그 후 그 디렉토리 자체를 다음 스테이지에서 그대로 복사하여 layer의 개수를 줄인다.
+FROM node:20-alpine as builder 
 
 WORKDIR /app
 
@@ -8,6 +10,14 @@ COPY package.json yarn.lock ./
 COPY apps/backend/package.json ./apps/backend/
 COPY apps/frontend/package.json ./apps/frontend/
 COPY apps/websocket/package.json ./apps/websocket/
+
+# node_modules를 가지고 있는 이미지
+# 이 이미지를 기반으로 각 workspace 별 이미지를 만들면 
+# yarn install 레이어를 공유하게 된다.
+FROM node:20-alpine
+
+# 호이스팅을 위해
+COPY --from=builder /app/apps /app/apps
 
 # 의존성 설치
 RUN yarn install --check-files

--- a/services/module/Dockerfile.init
+++ b/services/module/Dockerfile.init
@@ -1,0 +1,13 @@
+# 만약 octodocs-modules가 원격 저장소에 없으면 node 이미지를 사용한다.
+FROM node:20-alpine
+
+WORKDIR /app
+
+# 호이스팅을 위해
+COPY package.json yarn.lock ./
+COPY apps/backend/package.json ./apps/backend/
+COPY apps/frontend/package.json ./apps/frontend/
+COPY apps/websocket/package.json ./apps/websocket/
+
+# 의존성 설치
+RUN yarn install --check-files


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #47 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- octodocs-modules base 이미지를 자기 자신으로 설정하여 layer pull, layer push 시간 단축
- 원격 저장소에 자기 자신이 없거나 layer 수가 너무 많으면 node 이미지를 base로 사용
- 여러 이미지 build, push 병렬 처리 하여 시간 단축
- multi stage build로 COPY 명령어 줄여서 layer 수 감소

octodocs-modules는 websocket, backend, frontend에서 사용하는 모든 패키지를 가지고 있고 각 workspace 이미지는 이 이미지를 base로 사용하기 때문에 패키지 중복이 발생하지 않습니다.

octodocs-modules 이미지를 빌드할 때 octodocs-modules 이미지를 base로 사용하면 패키지가 추가되었을 때 추가된 패키지만 별도의 layer로 생성하여 기존 이미지에 쌓기 때문에 기존 yarn install layer를 그대로 사용할 수 있습니다.

하지만 이미지 빌드가 거듭되면 layer 수가 너무 늘어나기 때문에 일정 수가 넘어가면 모든 패키지를 다시 설치하여 layer 수를 초기화하도록 구현했습니다.

그리고 websocket, backend, nginx 빌드의 경우 모두 octodocs-modules 이미지에 의존하지만 독립적이기 때문에 병렬 build를 적용했습니다.

그리고 multi stage build를 적용하여 COPY 명령어 개수를 4개에서 1개로 줄였습니다.

octodocs-modules 이미지 push 시간 71초 감소 (83s -> 12s)
octodocs-modules 이미지 pull 시간 54초 감소 (68s -> 14)
octodocs-modules 이미지 빌드할 때마다 늘어나던 layer 수 4개 감소 (6개 -> 2개)
websocket, backend, websocket 이미지 빌드 시간 9초 감소 (45s -> 36s)
websocket, backend, websocket 이미지 푸시 시간 6초 감소 (12s -> 6s)


**base 이미지를 node로 지정했을 때**
![image (19)](https://github.com/user-attachments/assets/1a428c46-5432-4bc6-821f-9f38d93c5806)
5분 50초
https://github.com/boostcampwm-2024/refactor-web39-OctoDocs/actions/runs/12855189480

**base 이미지를 자기 자신으로 지정했을 때**
![image (20)](https://github.com/user-attachments/assets/d74ae9df-d3b6-4b6b-95ff-190d3eef2011)
3분 33초
https://github.com/boostcampwm-2024/refactor-web39-OctoDocs/actions/runs/12855161978


## 📑 참고 자료
