### PR TITLE
refactor: HTTP POST 방식으로 SSE 구현하여 스트리밍 적용

### DIFF
--- a/apps/backend/src/langchain/langchain.controller.ts
+++ b/apps/backend/src/langchain/langchain.controller.ts
@@ -1,32 +1,52 @@
 import { LangchainService } from './langchain.service';
 import { QueryRequest } from './dtos/queryRequest.dto';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation } from '@nestjs/swagger';
 import {
   Controller,
-  Get,
   Post,
-  Delete,
-  Param,
   Body,
   HttpCode,
   HttpStatus,
-  ParseIntPipe,
+  Res,
 } from '@nestjs/common';
 export enum LangchainResponseMessage {
   RESPONSE_RETURNED = 'AI의 응답을 받아왔습니다.',
 }
+
+export interface MessageEvent {
+  data: string | object;
+  id?: string;
+  type?: string;
+  retry?: number;
+}
+
 @Controller('langchain')
 export class LangchainController {
   constructor(private readonly landchainService: LangchainService) {}
-  @ApiResponse({ type: QueryRequest })
   @ApiOperation({ summary: 'AI에게 요청을 보냅니다.' })
   @Post('/')
   @HttpCode(HttpStatus.OK)
-  async query(@Body() body: QueryRequest) {
+  async query(@Body() body: QueryRequest, @Res() res) {
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Connection', 'keep-alive');
+
+    res.flushHeaders();
     const response = await this.landchainService.query(body.query);
-    return {
-      message: LangchainResponseMessage.RESPONSE_RETURNED,
-      response,
-    };
+    for await (const chunk of response) {
+      res.write(`${chunk.content}\n\n`);
+    }
+    res.end();
+    res.on('close', () => {
+      res.end();
+    });
   }
+
+  // async query(@Body() body: QueryRequest): Promise<Observable<MessageEvent>> {
+  //   console.log(body.query);
+  //   const response = await this.landchainService.query(body.query);
+  //   return from(response).pipe(
+  //     map((message) => ({ data: message['content'] })),
+  //   );
+  // }
 }

--- a/apps/backend/src/langchain/langchain.service.ts
+++ b/apps/backend/src/langchain/langchain.service.ts
@@ -79,7 +79,6 @@ export class LangchainService implements OnModuleInit {
       question: question,
       context: docsContent,
     });
-    const answer = await llm.invoke(messages);
-    return answer.content;
+    return await llm.stream(messages);
   }
 }

--- a/apps/frontend/src/features/AI/api/langchainApi.ts
+++ b/apps/frontend/src/features/AI/api/langchainApi.ts
@@ -12,3 +12,13 @@ export const postLangchain = async (query: PostLangchainResquest) => {
   );
   return res.data;
 };
+
+export const postFetchLangchain = async (query: PostLangchainResquest) => {
+  const url = `/api/langchain`;
+  const res = await Post<PostLangchainResponse, PostLangchainResquest>(
+    url,
+    query,
+  );
+  return res.data;
+};
+

--- a/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
+++ b/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
@@ -1,25 +1,23 @@
 import { useState } from "react";
 import { QuestionForm } from "../QuestionForm";
-import { useLangchain } from "../../model/useLangchain";
 
 export function AIPanel() {
   const [question, setQuestion] = useState("");
-  const { data: answer, isPending, mutate } = useLangchain();
-  console.log(answer);
+  // const { data: answer, isPending, mutate } = useLangchain();
+  const [answer, setAnswer] = useState("");
   return (
     <div className="z-8 absolute left-0 top-full mt-2 flex h-[720px] w-[500px] flex-col items-center rounded-md border-[1px] border-neutral-200 bg-white p-4 text-black shadow-md">
-      <QuestionForm onHandlePrevQustion={setQuestion} mutate={mutate} />
+      <QuestionForm
+        onHandlePrevQustion={setQuestion}
+        onHandleAnswer={setAnswer}
+      />
 
       <div className="mt-4 flex w-full flex-grow overflow-y-auto px-4">
         {question ? (
           <div className="text-md">
             <div className="font-bold">{question}</div>
             <hr className="my-3" />
-            {isPending ? (
-              <>로딩 중</>
-            ) : (
-              <div className="font-light">{answer?.response}</div>
-            )}
+            <div className="font-light">{answer}</div>
           </div>
         ) : (
           <div className="text-md flex h-full w-full items-center justify-center text-center font-medium">

--- a/services/nginx/conf.d/default.conf
+++ b/services/nginx/conf.d/default.conf
@@ -45,6 +45,18 @@ server {
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+
+    }
+
+    location /api/langchain {
+        proxy_buffering off;
+        
+        proxy_pass http://backend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
     }
 
     # WebSocket for YJS


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #74 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- fetch API로 HTTP POST SSE 구현
- Nginx buffering off
- AI 응답 스트리밍 구현 

EventSource 방식은 Body를 담을 수가 없어서 HTTP POST 방식으로 SSE를 구현했습니다.

API에서 직접 Response 객체 사용해서 chunk를 하나씩 보내주었습니다.

클라이언트에서는 스트림 데이터를 받을 때마다 출력에 추가해주었습니다.

buffering이 되지 않는 이슈가 있었는데 Nginx를 reverse proxy server로 이용했더니 default 설정에 buffering이 활성화 되었기 때문이었습니다.

/api/langchain을 이용할 때 buffering 기능을 꺼서 해결했습니다.