### PR TITLE
fix: postgres vector extension 활성화

### DIFF
--- a/apps/backend/src/page/page.repository.ts
+++ b/apps/backend/src/page/page.repository.ts
@@ -6,6 +6,12 @@ import { InjectDataSource } from '@nestjs/typeorm';
 @Injectable()
 export class PageRepository extends Repository<Page> implements OnModuleInit {
   async onModuleInit() {
+    // vector extension 활성화
+    await this.dataSource.query(`
+      CREATE EXTENSION IF NOT EXISTS vector
+    `);
+
+    // vector 컬럼 추가
     await this.dataSource.query(`
       ALTER TABLE page ADD COLUMN embedding vector(384);
       `);


### PR DESCRIPTION
<!--
선택 사항은 사용하지 않을 시, 지워주세요
-->

## 🔖 연관된 이슈

<!--#[이슈번호], #[이슈번호]-->

- #80 

## 📂 작업 내용

<!--이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)-->

- vector extension 활성화

vector extension이 활성화 되어있지 않아서 vector 컬럼을 생성하지 못 하는 이슈 해결했습니다.