### PR TITLE
RAG 질문 history 구현

### DIFF
--- a/apps/frontend/src/features/AI/model/useLangchainStore.ts
+++ b/apps/frontend/src/features/AI/model/useLangchainStore.ts
@@ -16,11 +16,11 @@ export const useLangchainStore = create<langchainStore>((set) => ({
   prevAnswers: [],
   setPrevQustions: (currQuestion: string) =>
     set((state) => ({
-      prevQustions: [...state.prevQustions, currQuestion],
+      prevQustions: [currQuestion, ...state.prevQustions],
     })),
   setPrevAnswers: (currAnswer: string) =>
     set((state) => ({
-      prevAnswers: [...state.prevAnswers, currAnswer],
+      prevAnswers: [currAnswer, ...state.prevAnswers],
     })),
   currQuestion: "",
   currAnswer: "",

--- a/apps/frontend/src/features/AI/model/useLangchainStore.ts
+++ b/apps/frontend/src/features/AI/model/useLangchainStore.ts
@@ -1,21 +1,35 @@
 import { create } from "zustand";
 
 interface langchainStore {
-  question: string;
-  answer: string;
-  setQuestion: (question: string) => void;
-  setAnswer: (answer: string | ((prev: string) => string)) => void;
+  prevQustions: string[];
+  prevAnswers: string[];
+  setPrevQustions: (currQuestion: string) => void;
+  setPrevAnswers: (currQuestion: string) => void;
+  currQuestion: string;
+  currAnswer: string;
+  setCurrQuestion: (newQuestion: string) => void;
+  setCurrAnswer: (answerOrUpdater: string | ((prev: string) => string)) => void;
 }
 
 export const useLangchainStore = create<langchainStore>((set) => ({
-  question: "",
-  answer: "",
-  setQuestion: (question: string) => set({ question }),
-  setAnswer: (answerOrUpdater: string | ((prev: string) => string)) =>
+  prevQustions: [],
+  prevAnswers: [],
+  setPrevQustions: (currQuestion: string) =>
     set((state) => ({
-      answer:
+      prevQustions: [...state.prevQustions, currQuestion],
+    })),
+  setPrevAnswers: (currAnswer: string) =>
+    set((state) => ({
+      prevAnswers: [...state.prevAnswers, currAnswer],
+    })),
+  currQuestion: "",
+  currAnswer: "",
+  setCurrQuestion: (newQuestion: string) => set({ currQuestion: newQuestion }),
+  setCurrAnswer: (answerOrUpdater: string | ((prev: string) => string)) =>
+    set((state) => ({
+      currAnswer:
         typeof answerOrUpdater === "function"
-          ? answerOrUpdater(state.answer)
+          ? answerOrUpdater(state.currAnswer)
           : answerOrUpdater,
     })),
 }));

--- a/apps/frontend/src/features/AI/model/useQnA.ts
+++ b/apps/frontend/src/features/AI/model/useQnA.ts
@@ -1,0 +1,22 @@
+import { useLangchainStore } from "./useLangchainStore";
+
+export const useQnA = () => {
+  const {
+    setPrevQustions,
+    setPrevAnswers,
+    currQuestion,
+    currAnswer,
+    setCurrAnswer,
+    setCurrQuestion,
+  } = useLangchainStore();
+
+  const updateQnA = (newQuestion: string) => {
+    setPrevQustions(currQuestion);
+    setPrevAnswers(currAnswer);
+
+    setCurrAnswer("");
+    setCurrQuestion(newQuestion);
+  };
+
+  return { updateQnA };
+};

--- a/apps/frontend/src/features/AI/model/useQnA.ts
+++ b/apps/frontend/src/features/AI/model/useQnA.ts
@@ -11,10 +11,13 @@ export const useQnA = () => {
   } = useLangchainStore();
 
   const updateQnA = (newQuestion: string) => {
-    setPrevQustions(currQuestion);
-    setPrevAnswers(currAnswer);
+    if (currQuestion && currAnswer) {
+      setPrevQustions(currQuestion);
+      setPrevAnswers(currAnswer);
 
-    setCurrAnswer("");
+      setCurrAnswer("");
+    }
+
     setCurrQuestion(newQuestion);
   };
 

--- a/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
+++ b/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
@@ -1,21 +1,23 @@
 import { QuestionForm } from "../QuestionForm";
-import { Divider } from "@/shared/ui";
 import { useLangchainStore } from "../../model/useLangchainStore";
 import { ExampleBlock } from "../ExampleBlock";
+import { QnA } from "../QnA";
 
 export function AIPanel() {
-  const { question, answer } = useLangchainStore();
+  const { prevQustions, prevAnswers, currQuestion, currAnswer } =
+    useLangchainStore();
 
   return (
     <div className="z-8 absolute left-0 top-full mt-2 flex h-[76vh] w-[26vw] min-w-[340px] flex-col items-center rounded-md border-[1px] border-neutral-200 bg-white p-4 text-black shadow-md">
       <QuestionForm />
 
       <div className="mt-4 flex w-full flex-grow overflow-y-auto px-4">
-        {question ? (
+        {currQuestion ? (
           <div className="text-md w-full">
-            <div className="font-bold">{question}</div>
-            <Divider direction="horizontal" className="my-3" />
-            <div className="font-light">{answer}</div>
+            {prevQustions.map((q, i) => (
+              <QnA question={q} answer={prevAnswers[i]} />
+            ))}
+            <QnA question={currQuestion} answer={currAnswer} />
           </div>
         ) : (
           <div className="flex h-full w-full flex-col items-center justify-center gap-6 text-center text-lg font-medium">

--- a/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
+++ b/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
@@ -10,9 +10,7 @@ export function AIPanel() {
   const QnAsRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (QnAsRef.current) {
-      QnAsRef.current.scrollTop = QnAsRef.current.scrollHeight;
-    }
+    if (QnAsRef.current) QnAsRef.current.scrollTop = 0;
   }, [currQuestion]);
 
   return (
@@ -21,11 +19,11 @@ export function AIPanel() {
 
       <div ref={QnAsRef} className="mt-2 flex w-full flex-grow overflow-y-auto">
         {currQuestion ? (
-          <div className="text-md w-full">
+          <div className="text-md w-full p-1">
+            <QnA question={currQuestion} answer={currAnswer} />
             {prevQustions.map((q, i) => (
               <QnA question={q} answer={prevAnswers[i]} />
             ))}
-            <QnA question={currQuestion} answer={currAnswer} />
           </div>
         ) : (
           <div className="flex h-full w-full flex-col items-center justify-center gap-6 text-center text-lg font-medium">

--- a/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
+++ b/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
@@ -7,22 +7,29 @@ import { useEffect, useRef } from "react";
 export function AIPanel() {
   const { prevQustions, prevAnswers, currQuestion, currAnswer } =
     useLangchainStore();
-  const QnAsRef = useRef<HTMLDivElement>(null);
+  const currQnARef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (QnAsRef.current) QnAsRef.current.scrollTop = 0;
+    if (currQnARef.current) {
+      currQnARef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
   }, [currQuestion]);
 
   return (
     <div className="z-8 absolute left-0 top-full mt-2 flex h-[76vh] w-[26vw] min-w-[340px] flex-col items-center rounded-md border-[1px] border-neutral-200 bg-white p-4 text-black shadow-md">
       <QuestionForm />
 
-      <div ref={QnAsRef} className="mt-2 flex w-full flex-grow overflow-y-auto">
+      <div className="mt-2 flex w-full flex-grow overflow-y-auto">
         {currQuestion ? (
           <div className="text-md w-full p-1">
-            <QnA question={currQuestion} answer={currAnswer} />
+            <div ref={currQnARef}>
+              <QnA question={currQuestion} answer={currAnswer} />
+            </div>
             {prevQustions.map((q, i) => (
-              <QnA question={q} answer={prevAnswers[i]} />
+              <QnA key={i} question={q} answer={prevAnswers[i]} />
             ))}
           </div>
         ) : (

--- a/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
+++ b/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
@@ -2,16 +2,24 @@ import { QuestionForm } from "../QuestionForm";
 import { useLangchainStore } from "../../model/useLangchainStore";
 import { ExampleBlock } from "../ExampleBlock";
 import { QnA } from "../QnA";
+import { useEffect, useRef } from "react";
 
 export function AIPanel() {
   const { prevQustions, prevAnswers, currQuestion, currAnswer } =
     useLangchainStore();
+  const QnAsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (QnAsRef.current) {
+      QnAsRef.current.scrollTop = QnAsRef.current.scrollHeight;
+    }
+  }, [currQuestion]);
 
   return (
     <div className="z-8 absolute left-0 top-full mt-2 flex h-[76vh] w-[26vw] min-w-[340px] flex-col items-center rounded-md border-[1px] border-neutral-200 bg-white p-4 text-black shadow-md">
       <QuestionForm />
 
-      <div className="mt-2 flex w-full flex-grow overflow-y-auto">
+      <div ref={QnAsRef} className="mt-2 flex w-full flex-grow overflow-y-auto">
         {currQuestion ? (
           <div className="text-md w-full">
             {prevQustions.map((q, i) => (

--- a/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
+++ b/apps/frontend/src/features/AI/ui/AIPanel/index.tsx
@@ -11,7 +11,7 @@ export function AIPanel() {
     <div className="z-8 absolute left-0 top-full mt-2 flex h-[76vh] w-[26vw] min-w-[340px] flex-col items-center rounded-md border-[1px] border-neutral-200 bg-white p-4 text-black shadow-md">
       <QuestionForm />
 
-      <div className="mt-4 flex w-full flex-grow overflow-y-auto px-4">
+      <div className="mt-2 flex w-full flex-grow overflow-y-auto">
         {currQuestion ? (
           <div className="text-md w-full">
             {prevQustions.map((q, i) => (

--- a/apps/frontend/src/features/AI/ui/QnA/index.tsx
+++ b/apps/frontend/src/features/AI/ui/QnA/index.tsx
@@ -1,5 +1,3 @@
-import { Divider } from "@/shared/ui";
-
 interface QnAType {
   question: string;
   answer: string;
@@ -7,10 +5,11 @@ interface QnAType {
 
 export function QnA({ question, answer }: QnAType) {
   return (
-    <div>
-      <div className="font-bold">{question}</div>
-      <Divider direction="horizontal" className="my-3" />
-      <div className="font-light">{answer}</div>
+    <div className="py-3">
+      <div className="mb-1 w-full rounded-md border-[1px] border-[#d0d9e0] bg-[#f5f6fa] px-3 py-2 font-bold">
+        {question}
+      </div>
+      <div className="p-2 font-light">{answer}</div>
     </div>
   );
 }

--- a/apps/frontend/src/features/AI/ui/QnA/index.tsx
+++ b/apps/frontend/src/features/AI/ui/QnA/index.tsx
@@ -9,7 +9,7 @@ export function QnA({ question, answer }: QnAType) {
       <div className="mb-1 w-full rounded-md border-[1px] border-[#d0d9e0] bg-[#f5f6fa] px-3 py-2 font-bold">
         {question}
       </div>
-      <div className="p-2 font-light">{answer}</div>
+      <div className="min-h-[100px] p-2 font-light">{answer}</div>
     </div>
   );
 }

--- a/apps/frontend/src/features/AI/ui/QnA/index.tsx
+++ b/apps/frontend/src/features/AI/ui/QnA/index.tsx
@@ -1,0 +1,16 @@
+import { Divider } from "@/shared/ui";
+
+interface QnAType {
+  question: string;
+  answer: string;
+}
+
+export function QnA({ question, answer }: QnAType) {
+  return (
+    <div>
+      <div className="font-bold">{question}</div>
+      <Divider direction="horizontal" className="my-3" />
+      <div className="font-light">{answer}</div>
+    </div>
+  );
+}

--- a/apps/frontend/src/features/AI/ui/QuestionForm/index.tsx
+++ b/apps/frontend/src/features/AI/ui/QuestionForm/index.tsx
@@ -2,12 +2,14 @@ import { ArrowDown } from "lucide-react";
 import { FormEvent, useEffect, useRef, useState } from "react";
 import { useLangchain } from "../../model/useLangchain";
 import { useLangchainStore } from "../../model/useLangchainStore";
+import { useQnA } from "../../model/useQnA";
 
 export function QuestionForm() {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [newQuestion, setnewQuestion] = useState("");
-  const { setAnswer, setQuestion } = useLangchainStore();
+  const { setCurrAnswer } = useLangchainStore();
   const { mutateLangchain } = useLangchain();
+  const { updateQnA } = useQnA();
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -19,11 +21,10 @@ export function QuestionForm() {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setnewQuestion("");
-    setAnswer("");
-    setQuestion(newQuestion);
+    updateQnA(newQuestion);
 
     await mutateLangchain(newQuestion, (chunk: string) => {
-      setAnswer((prev) => prev + chunk);
+      setCurrAnswer((prev) => prev + chunk);
     });
   };
 


### PR DESCRIPTION
## 🔖 연관된 이슈

closes #83

-

## 📂 작업 내용

- 이전 질문 내역을 관리하는 상태 추가
   - zustand를 사용하여 상태 관리
   - 최신 순으로 구현
- QnA 컴포넌트 분리 및 디자인 변경
- 스크롤 이동 시 애니매이션 추가

## 📑 참고 자료 & 스크린샷 (선택)


https://github.com/user-attachments/assets/7391d35d-6263-41f5-ba26-27f2d4d9c240


